### PR TITLE
Update README.md

### DIFF
--- a/src/usr/README.md
+++ b/src/usr/README.md
@@ -296,7 +296,7 @@ If you set a different value in this property, you can see that the active butto
 <br/>
 
 Obviously, to switch the active button on the `onChangeActiveTab` event, you need to change the `Active Tab Type` property.
-You have to describe it somehow in your `exchange-navigation-filter-by-click` flow.
+You have to describe it somehow in your `change-navigation-filter-by-click` flow.
 
 > Changing properties in instances of components is the responsibility of the corresponding functions. 
 In this project, such functions are included in function sets with names identical to the names of components whose properties they can change.


### PR DESCRIPTION
1 change-navigation-filter-by-click instead of exchange-navigation-filter-by-click

2
```
The Application element will be automatically replaced by the mainPageNavigationTabs instance element.
```

for me the application element is not remplaced
![image](https://user-images.githubusercontent.com/4020744/76803305-cb9f4b80-67d9-11ea-91b9-360401a29cd0.png)

3. I can't link onChangeActiveTab to setActiveNavigationTAb until onApplicationStart was linked to props

![image](https://user-images.githubusercontent.com/4020744/76803706-c0005480-67da-11ea-8525-cf78b84f4c0a.png)
------
![image](https://user-images.githubusercontent.com/4020744/76803741-d5757e80-67da-11ea-93ef-b602c50ae2ae.png)

4. 
```
Connect the navigationTabsProps output of the setActiveNavigationTab function to the input of the new mainPageNavigationTabs instance
```
 Isn't the same instance of mainPageNavigationTabs  ??? For me there is only one instance ???
